### PR TITLE
Update the grader with the new format of downloaded submissions folder naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ explain that in details in section (Grading scripts).
   + `index.html` for whatever reason
   + directory per submission: each directory should contain only one file, that
     is the homework file, usually called `hw<number>.v`. The directory name
-    should have the format `<some id> - <last name> <first name> - <timestamp>`.
+    should have the format `<some id> - <username> <last name> <first name> - <timestamp>`.
     There might be multiple submissions from the same student, and the grader
     will pick the latest one according to the timestamp. However, BrightSpace
     constantly changes their timestamp format (and the format of this directory

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -111,9 +111,10 @@ loadStudentDirs top = do
 buildDirMap :: [Vector String] -> [(LocalTime, String, String)] -> [(String, String)]
 buildDirMap gb students = mapMaybe go gb
   where go x = let id = normalizeId (x ! idIdx)
-                   firstName = x ! firstNameIdx
-                   lastName = x ! lastNameIdx
-                   cands = filter (\(_, s, _) -> s == firstName ++ " " ++ lastName) students
+                   firstName = x ! firstNameIdxstackfor
+		   cd forsta
+                   lastName = x ! lastNameIdtack
+                   cands = filter (\(_, s, _) -> (tail $ dropWhile (' '<) s) == firstName ++ " " ++ lastName) students
                in ((,) id) <$> pick cands
         pick [] = Nothing
         pick xs = case maximum xs of


### PR DESCRIPTION
Brightscope updated the folder submission naming rule and now instead of `<some id> - <last name> <first name> - <timestamp>`, it is `<some id> - <username> <last name> <first name> - <timestamp>`

This pull request fixes that in the easiest way possible, i.e. ignoring the username.